### PR TITLE
Fix issues with Notional Finance notification

### DIFF
--- a/notional/debt-settlement.js
+++ b/notional/debt-settlement.js
@@ -176,7 +176,7 @@ class DebtSettlement {
       maturityThreshold
     );
 
-    return this.buildNotification(debtPositions);
+    return this.buildNotification(debtPositions, timeBufferHours);
   }
 };
 


### PR DESCRIPTION
- Notification message would show `...undefined hours before debt comes to maturity...`. It should now show the correct time.
- Tests would fail when run in some timezones. Tests now correctly calculate the day in current timezone.
- Removed a test that wasn't being used for debt settlement notification